### PR TITLE
Add Arch Tools — 61 AI tools with x402 USDC payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Updated monthly. PRs welcome.
 - [Firecrawl](https://github.com/mendableai/firecrawl) - Web scraping API built for LLMs that converts websites to clean markdown.
 - [Notte](https://github.com/nottelabs/notte) - Browser automation for production pipelines.
 - [Pilot Protocol](https://github.com/TeoSlayer/pilotprotocol) - Networking stack for distributed agent systems with encrypted tunnels.
+- [Arch Tools](https://archtools.dev) - 61 production-ready AI tools (code analysis, web scraping, image generation, NLP, crypto, search) accessible via REST API and MCP protocol. Native x402 USDC micropayments on Base, Polygon, Avalanche, and Solana.
 
 ## Low and No-Code Builders
 


### PR DESCRIPTION
Adds [Arch Tools](https://archtools.dev) to the Agent Tooling and Infrastructure section.

**Arch Tools** provides 61 production-ready AI tools (code analysis, web scraping, image generation, NLP, crypto, search, and more) accessible via REST API and MCP protocol. Native x402 USDC micropayments on Base, Polygon, Avalanche, and Solana. Built for AI agents.

- **GitHub:** https://github.com/Deesmo/Arch-AI-Tools
- **MCP endpoint:** https://arch-tools-mcp.onrender.com/mcp
- **x402scan:** https://x402scan.com/resource/archtools.dev