### PR TITLE
Add KubeStellar Console to Agent Tooling and Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [E2B](https://github.com/e2b-dev/e2b) - Cloud sandboxes for AI agents to run code securely in isolated environments.
 - [Engram](https://github.com/kwstx/engram_translator) - Universal bridge for multi-protocol AI agent systems with automated semantic mapping.
 - [Firecrawl](https://github.com/firecrawl/firecrawl) - Web scraping API built for LLMs that converts websites to clean, structured markdown.
-- [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with MCP bridge enabling AI agents to manage workloads across edge and cloud clusters.
+- [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with MCP bridge enabling AI agents to manage and observe workloads across edge and cloud clusters.
 - [Notte](https://github.com/nottelabs/notte) - Browser automation engine optimized for production AI pipelines.
 - [Pilot Protocol](https://github.com/TeoSlayer/pilotprotocol) - Networking stack for distributed agent systems with encrypted tunnels.
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [E2B](https://github.com/e2b-dev/e2b) - Cloud sandboxes for AI agents to run code securely in isolated environments.
 - [Engram](https://github.com/kwstx/engram_translator) - Universal bridge for multi-protocol AI agent systems with automated semantic mapping.
 - [Firecrawl](https://github.com/firecrawl/firecrawl) - Web scraping API built for LLMs that converts websites to clean, structured markdown.
+- [KubeStellar Console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with MCP bridge enabling AI agents to manage workloads across edge and cloud clusters.
 - [Notte](https://github.com/nottelabs/notte) - Browser automation engine optimized for production AI pipelines.
 - [Pilot Protocol](https://github.com/TeoSlayer/pilotprotocol) - Networking stack for distributed agent systems with encrypted tunnels.
 


### PR DESCRIPTION
## Add KubeStellar Console

Adds [KubeStellar Console](https://github.com/kubestellar/console) to the Agent Tooling and Infrastructure section.

**What it is:** Multi-cluster Kubernetes dashboard with a built-in MCP bridge that enables AI agents (Claude, Cursor, etc.) to manage and observe workloads across edge and cloud clusters through natural language.

**Why it fits Agent Tooling & Infrastructure:** KubeStellar Console provides the Kubernetes infrastructure layer that AI agents depend on — MCP bridge to K8s APIs, multi-cluster management, real-time observability, and integrations with 20+ CNCF projects (Argo, Kyverno, Istio, Prometheus, etc.).

- GitHub: https://github.com/kubestellar/console
- CNCF Sandbox project (Apache 2.0)
- Live demo: https://console.kubestellar.io