### PR TITLE
Add Memoir to Memory and Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@
 - [Langmem](https://github.com/langchain-ai/langmem) - Helps agents learn and adapt from their interactions over time with persistent memory (🏷️ `Python` `LangChain` `SDK`).
 - [Lorg](https://github.com/lorg-ai/lorg) - Permanent intelligence archive for AI agents with structured contributions and cryptographically backed trust scores (🏷️ `Python` `Archive` `SDK`).
 - [Mem0](https://github.com/mem0ai/mem0) - Memory layer for AI applications with long-term, short-term, and semantic memory extraction (🏷️ `Python` `Vector` `Cloud`).
+- [Memoir](https://github.com/zhangfengcdt/memoir) - Git-like versioned semantic memory for AI agents with branching, commits, and cryptographic integrity over hierarchical paths (🏷️ `Python` `Git-like` `SDK`).
 - [Memvid](https://github.com/memvid/memvid) - Replace complex RAG pipelines with a serverless, single-file memory layer for instant retrieval (🏷️ `Python` `Multimodal` `SDK`).
 - [Milvus](https://github.com/milvus-io/milvus) - Scales vector search to billions of embeddings for large-scale agent knowledge bases (🏷️ `Go` `Python` `Platform`).
 - [Motorhead](https://github.com/getmetal/motorhead) - Manages conversation context windows for agents with automatic background summarization (🏷️ `Rust` `Python` `SDK`).


### PR DESCRIPTION
Memoir is a Git-like versioned semantic memory system for AI agents, with branching, commits, and cryptographic integrity over hierarchical semantic paths instead of opaque vector stores.

## What does this PR do?

<!-- Check all that apply -->

- [x] Adds a new tool
- [ ] Updates an existing entry (stars, links, description)
- [ ] Removes an abandoned / dead project
- [ ] Fixes a broken link
- [ ] Improves structure or formatting
- [ ] Other: ___

---

## For new tool additions

**Tool name:** Memoir
**Category it belongs in:** Memory and Context
**GitHub URL:** https://github.com/zhangfengcdt/memoir
**Site URL (if any):** https://www.memoir-ai.dev/

### Why does this tool belong on the list?

Memoir brings Git-like version control to AI agent memory — branching, commits, blame, and cryptographic integrity over hierarchical semantic paths (e.g. `profile.professional.skills.python`) — instead of treating memory as a flat vector store or append-only blob.

This addresses failure modes the existing vector-DB and `CLAUDE.md`-style entries don't: context contamination across `git checkout`, prefix-cache invalidation on memory edits, and lack of audit/rollback for poisoned memories.

### Pre-submission checklist

- [x] The repo has had a commit in the last **6 months** (last commit 2026-05-04)
- [x] This tool is **meaningfully different** from existing entries (versioning + semantic paths vs. vector stores)
- [x] The tool has a working README or docs site
- [x] My entry follows the [format in CONTRIBUTING.md](https://github.com/ARUNAGIRINATHAN-K/awesome-ai-agents/Contributing.md)
exactly
- [x] The entry is placed in **alphabetical order** within its section (between Mem0 and Memvid)
- [x] All links open correctly and go to the right place
- [ ] Description is exactly **two sentences** — no promotional language

---

## For updates or removals

**What changed and why:**

N/A — new addition only.

---

## Anything else?

The current entry is a single sentence to match the existing list's style — every other entry in **Memory and Context** is also one sentence. Happy to expand it to two sentences if the template's rule should take precedence over current convention.