### PR TITLE
Add CAJAL: Local Scientific Paper Generation Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ AI platforms that conduct autonomous multi-step research, synthesize findings fr
 | Gemini Research  | 1M tokens      | Google Search + KG          |
 | Perplexity Pro   | Variable       | Real-time cited search      |
 
-- [CAJAL](https://github.com/Agnuxo1/CAJAL) - Local AI agent that generates publication-ready scientific papers with real arXiv citations, tribunal scoring, and 100% offline execution via Ollama (🏷️ `Python` `Ollama` `Local`).
+- [CAJAL](https://github.com/Agnuxo1/CAJAL) - Local AI agent that generates publication-ready IMRaD scientific papers with verified arXiv citations and AI tribunal scoring (🏷️ `Python` `Ollama` `Local`).
 - [ChatGPT Deep Research](https://openai.com/index/introducing-deep-research) - Conducts extended reasoning with web browsing to produce structured research reports with Canvas output (🏷️ `Cloud` `OpenAI` `Web`).
 - [Claude Deep Research](https://www.anthropic.com/research) - Performs multi-step investigation with verified source citations and 200K token context window (🏷️ `Cloud` `Anthropic` `Web`).
 - [DeerFlow](https://github.com/bytedance/deer-flow) - Multi-agent research system from ByteDance with planning and execution loops for autonomous investigation (🏷️ `Python` `Open-Source` `Research`).

--- a/README.md
+++ b/README.md
@@ -529,12 +529,12 @@ AI platforms that conduct autonomous multi-step research, synthesize findings fr
 | Gemini Research  | 1M tokens      | Google Search + KG          |
 | Perplexity Pro   | Variable       | Real-time cited search      |
 
+- [CAJAL](https://github.com/Agnuxo1/CAJAL) - Local AI agent that generates publication-ready scientific papers with real arXiv citations, tribunal scoring, and 100% offline execution via Ollama (🏷️ `Python` `Ollama` `Local`).
 - [ChatGPT Deep Research](https://openai.com/index/introducing-deep-research) - Conducts extended reasoning with web browsing to produce structured research reports with Canvas output (🏷️ `Cloud` `OpenAI` `Web`).
 - [Claude Deep Research](https://www.anthropic.com/research) - Performs multi-step investigation with verified source citations and 200K token context window (🏷️ `Cloud` `Anthropic` `Web`).
 - [DeerFlow](https://github.com/bytedance/deer-flow) - Multi-agent research system from ByteDance with planning and execution loops for autonomous investigation (🏷️ `Python` `Open-Source` `Research`).
 - [Gemini Deep Research](https://blog.google/products/gemini/google-gemini-deep-research) - Leverages Google Search and Knowledge Graph integration with 1M token context for breadth-first research (🏷️ `Cloud` `Google` `Web`).
 - [Perplexity Pro](https://www.perplexity.ai) - Provides real-time search answers with inline citations and follow-up threads for iterative research (🏷️ `Cloud` `Freemium` `Web`).
-- [CAJAL](https://github.com/Agnuxo1/CAJAL) - Local AI agent that generates publication-ready scientific papers with real arXiv citations, tribunal scoring, and 100% offline execution via Ollama (🏷️ `Python` `Ollama` `Local`).
 
 ## Prompt-to-App Builders
 

--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ AI platforms that conduct autonomous multi-step research, synthesize findings fr
 - [DeerFlow](https://github.com/bytedance/deer-flow) - Multi-agent research system from ByteDance with planning and execution loops for autonomous investigation (🏷️ `Python` `Open-Source` `Research`).
 - [Gemini Deep Research](https://blog.google/products/gemini/google-gemini-deep-research) - Leverages Google Search and Knowledge Graph integration with 1M token context for breadth-first research (🏷️ `Cloud` `Google` `Web`).
 - [Perplexity Pro](https://www.perplexity.ai) - Provides real-time search answers with inline citations and follow-up threads for iterative research (🏷️ `Cloud` `Freemium` `Web`).
-- [CAJAL](https://github.com/Agnuxo1/CAJAL) - Local AI agent that generates publication-ready scientific papers with real arXiv citations, tribunal scoring, and 100% offline execution via Ollama (🏷️ `Local` `Open-Source` `Research`).
+- [CAJAL](https://github.com/Agnuxo1/CAJAL) - Local AI agent that generates publication-ready scientific papers with real arXiv citations, tribunal scoring, and 100% offline execution via Ollama (🏷️ `Python` `Ollama` `Local`).
 
 ## Prompt-to-App Builders
 

--- a/README.md
+++ b/README.md
@@ -534,6 +534,7 @@ AI platforms that conduct autonomous multi-step research, synthesize findings fr
 - [DeerFlow](https://github.com/bytedance/deer-flow) - Multi-agent research system from ByteDance with planning and execution loops for autonomous investigation (🏷️ `Python` `Open-Source` `Research`).
 - [Gemini Deep Research](https://blog.google/products/gemini/google-gemini-deep-research) - Leverages Google Search and Knowledge Graph integration with 1M token context for breadth-first research (🏷️ `Cloud` `Google` `Web`).
 - [Perplexity Pro](https://www.perplexity.ai) - Provides real-time search answers with inline citations and follow-up threads for iterative research (🏷️ `Cloud` `Freemium` `Web`).
+- [CAJAL](https://github.com/Agnuxo1/CAJAL) - Local AI agent that generates publication-ready scientific papers with real arXiv citations, tribunal scoring, and 100% offline execution via Ollama (🏷️ `Local` `Open-Source` `Research`).
 
 ## Prompt-to-App Builders
 


### PR DESCRIPTION
**CAJAL** is a local AI agent specialized in generating publication-ready scientific papers with real arXiv citations and tribunal scoring.

### What makes it distinct
- 100% offline execution via Ollama/llama.cpp (4B-9B GGUF models)
- Generates complete IMRaD papers with verified citations
- AI Tribunal scoring (3 reviewers, iterative rewrite)
- MIT licensed, open source

### Links
- GitHub: https://github.com/Agnuxo1/CAJAL
- HuggingFace: https://huggingface.co/Agnuxo/CAJAL-9B-P2PCLAW
- Paper: https://arxiv.org/pdf/2604.19792

Added to Deep Research Agents section.