### PR TITLE
Add NotFair under MCP (Model Context Protocol)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The protocol layer that enables agents to discover tools, communicate with each 
 - [HCS Agent Protocol](https://github.com/hashgraph/hedera-agent-kit) - Hedera open standards for agent identity with trustless P2P communication and 187K+ verified agents (🏷️ `TypeScript` `Hedera` `Protocol`).
 - [MCP Registry](https://github.com/modelcontextprotocol) - Official Model Context Protocol specification and server implementations for standardized tool access (🏷️ `JSON` `Standard` `Registry`).
 - [mcp-nest](https://github.com/CharanBharathula/mcp-nest) - Unified Model Context Protocol (MCP) server for executing code and managing files (🏷️ `Python` `MCP` `CLI`).
-- [NotFair](https://notfair.co) - Hosted Google Ads MCP server connecting Claude and AI agents to a Google Ads account: diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API with a built-in human-approval gate (🏷️ `Cloud` `MCP` `Marketing`).
+- [NotFair](https://notfair.co) - Hosted Google Ads MCP server for diagnosing, optimizing, and executing campaign changes via the Google Ads API with a human-approval gate (🏷️ `Cloud` `MCP` `Marketing`).
 - [Toolhouse](https://toolhouse.ai) - Cloud-hosted tool infrastructure for agents with optimized execution and low-latency access (🏷️ `Python` `Cloud` `API`).
 - [Zapier MCP Server](https://zapier.com/mcp) - Connect agents to 7,000+ app integrations via MCP, powered by Zapier's automation platform (🏷️ `Cloud` `Zapier` `API`).
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ The protocol layer that enables agents to discover tools, communicate with each 
 - [HCS Agent Protocol](https://github.com/hashgraph/hedera-agent-kit) - Hedera open standards for agent identity with trustless P2P communication and 187K+ verified agents (🏷️ `TypeScript` `Hedera` `Protocol`).
 - [MCP Registry](https://github.com/modelcontextprotocol) - Official Model Context Protocol specification and server implementations for standardized tool access (🏷️ `JSON` `Standard` `Registry`).
 - [mcp-nest](https://github.com/CharanBharathula/mcp-nest) - Unified Model Context Protocol (MCP) server for executing code and managing files (🏷️ `Python` `MCP` `CLI`).
+- [NotFair](https://notfair.co) - Hosted Google Ads MCP server connecting Claude and AI agents to a Google Ads account: diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API with a built-in human-approval gate (🏷️ `Cloud` `MCP` `Marketing`).
 - [Toolhouse](https://toolhouse.ai) - Cloud-hosted tool infrastructure for agents with optimized execution and low-latency access (🏷️ `Python` `Cloud` `API`).
 - [Zapier MCP Server](https://zapier.com/mcp) - Connect agents to 7,000+ app integrations via MCP, powered by Zapier's automation platform (🏷️ `Cloud` `Zapier` `API`).
 


### PR DESCRIPTION
Adding NotFair under MCP (Model Context Protocol), alphabetically between mcp-nest and Toolhouse.

NotFair is a hosted Google Ads MCP server for Claude and other AI agents. It connects to a Google Ads account, diagnoses campaign performance (CPA, ROAS, search-term waste, quality scores), recommends optimizations (bids, budgets, negative keywords, ad copy), and executes approved changes via the official Google Ads API with a built-in human-approval gate. Free tier available.

Linked to the product page since NotFair is a hosted service without a public source repo, similar to Toolhouse and Zapier MCP Server in the same section.