### PR TITLE
Add TheCrawler to Agent Tooling and Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [ScrapeGraphAI](https://github.com/ScrapeGraphAI/Scrapegraph-ai) - Python web-scraping library that uses LLMs to build intelligent scraping pipelines from natural-language instructions (🏷️ `Python` `LangChain` `SDK`).
 - [Surya](https://github.com/datalab-to/surya) - Runs OCR and layout detection on documents in 90+ languages for multilingual document agents (🏷️ `Python` `PDF` `CLI`).
 - [Tavily](https://github.com/tavily-ai/tavily-python) - Search API purpose-built for LLM agents providing real-time, accurate web data with source citations (🏷️ `Python` `Cloud` `API`).
+- [TheCrawler](https://github.com/manchittlab/TheCrawler) - GitHub-source MCP server and CLI for web crawling, extraction diagnostics, and validated extraction contracts for agent workflows (🏷️ `TypeScript` `MCP` `CLI`).
 - [Unstructured](https://github.com/Unstructured-IO/unstructured) - Ingests and preprocesses documents across 25+ file types for downstream LLM and agent pipelines (🏷️ `Python` `Pipeline` `SDK`).
 
 ## Low and No-Code Builders

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [ScrapeGraphAI](https://github.com/ScrapeGraphAI/Scrapegraph-ai) - Python web-scraping library that uses LLMs to build intelligent scraping pipelines from natural-language instructions (🏷️ `Python` `LangChain` `SDK`).
 - [Surya](https://github.com/datalab-to/surya) - Runs OCR and layout detection on documents in 90+ languages for multilingual document agents (🏷️ `Python` `PDF` `CLI`).
 - [Tavily](https://github.com/tavily-ai/tavily-python) - Search API purpose-built for LLM agents providing real-time, accurate web data with source citations (🏷️ `Python` `Cloud` `API`).
-- [TheCrawler](https://github.com/manchittlab/TheCrawler) - GitHub-source MCP server and CLI for web crawling, extraction diagnostics, and validated extraction contracts for agent workflows (🏷️ `TypeScript` `MCP` `CLI`).
+- [TheCrawler](https://github.com/manchittlab/TheCrawler) - MCP server and CLI for web crawling, extraction diagnostics, and validated extraction contracts for agent workflows (🏷️ `TypeScript` `MCP` `CLI`).
 - [Unstructured](https://github.com/Unstructured-IO/unstructured) - Ingests and preprocesses documents across 25+ file types for downstream LLM and agent pipelines (🏷️ `Python` `Pipeline` `SDK`).
 
 ## Low and No-Code Builders


### PR DESCRIPTION
## What does this PR do?

- [x] Adds a new tool
- [ ] Updates an existing entry (stars, links, description)
- [ ] Removes an abandoned / dead project
- [ ] Fixes a broken link
- [ ] Improves structure or formatting
- [ ] Other: ___

---

## For new tool additions

**Tool name:** TheCrawler
**Category it belongs in:** Agent Tooling and Infrastructure
**GitHub URL:** https://github.com/manchittlab/TheCrawler
**Site URL (if any):** https://www.miaibot.ai/tools/thecrawler

### Why does this tool belong on the list?

TheCrawler is a web crawling and extraction tool for agent workflows, with MCP server and CLI surfaces. It belongs in Agent Tooling and Infrastructure because this section already includes web scrapers and agent-ingestion tools such as Crawl4AI, Firecrawl, Jina Reader, and ScrapeGraphAI.

### Pre-submission checklist

- [x] The repo has had a commit in the last **6 months**
- [x] This tool is **meaningfully different** from existing entries
- [x] The tool has a working README or docs site
- [x] My entry follows the [format in CONTRIBUTING.md](https://github.com/ARUNAGIRINATHAN-K/awesome-ai-agents-2026/blob/main/Contributing.md) exactly
- [x] The entry is placed in **alphabetical order** within its section
- [x] All links open correctly and go to the right place
- [ ] Description is exactly **two sentences** — no promotional language

---

## Anything else?

The unchecked description item is intentional: `Contributing.md` says the entry description must be exactly one sentence, and the existing section entries use one-sentence descriptions. This PR follows `Contributing.md` and the existing list format rather than changing the entry to two sentences.