### PR TITLE
Add Alfred to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@
 ## Coding Agents
 
 - [Aider](https://github.com/Aider-AI/aider) - Terminal-first pair programmer that edits code in local repos, preserves Git history, and supports multi-file changes (🏷️ `Python` `CLI` `Local`).
+- [Alfred](https://github.com/luminik-io/alfred-os) - Self-hosted runtime that turns GitHub issues into reviewed pull requests through autonomous Claude Code and Codex agents (🏷️ `Python` `CLI` `Local`).
 - [Amazon Q Developer](https://aws.amazon.com/q/developer/) - AWS-native AI coding assistant with Lambda, CloudWatch, infrastructure support, and security scanning (🏷️ `Python` `AWS` `IDE`).
 - [AutoGPT](https://github.com/Significant-Gravitas/AutoGPT) - Mature autonomous agent platform with Forge framework and public benchmarks for evaluating agent capabilities (🏷️ `Python` `Forge` `CLI`).
 - [Claude Code](https://github.com/anthropics/claude-code) - Terminal-first agentic coding from Anthropic with Computer Use integration, multi-file edits, persistent shell sessions, Git operations, and fine-tuning support (🏷️ `TypeScript` `CLI` `Local` `[Anthropic]`).


### PR DESCRIPTION
Adds Alfred to the Coding Agents section.

### Entry
`- [Alfred](https://github.com/luminik-io/alfred-os) - Self-hosted runtime that turns GitHub issues into reviewed pull requests through autonomous Claude Code and Codex agents (🏷️ `Python` `CLI` `Local`).`

### Why it fits
Alfred is a self-hosted Python runtime for autonomous engineering agents that drive Claude Code and Codex on a developer's own subscription. GitHub issues come in, reviewed pull requests come out. Worktree isolation per firing, label-driven state, role-based engine routing across Claude Code and Codex, and Slack summaries. Sits next to Aider, Cline, opencode, OpenHands in the same section.

### CONTRIBUTING compliance
- One entry per PR.
- Format follows the canonical example: `- [Name](url) - One sentence. (🏷️ tags)`
- Single sentence, ends with a period, hyphen separator (not em-dash).
- No promotional adjectives.
- Placed in Coding Agents, alphabetically between Aider and Amazon Q Developer.
- Inclusion criteria: directly related to AI agents (yes), actively maintained (last commit days ago), publicly available (https://github.com/luminik-io/alfred-os and https://alfred.luminik.io), not a duplicate, functional (MIT, install guide and runnable examples in repo).

### Sources
- https://github.com/luminik-io/alfred-os
- https://alfred.luminik.io/