### PR TITLE
feat: add Cloud Operations & GreenOps category with GreenOps Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center">
+``<div align="center">
 
 ![](img/ARUNAGIRINATHAN-K.png)
 
@@ -777,3 +777,6 @@ Your contributions are what keep this list useful. Read [Contributing.md](Contri
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=ARUNAGIRINATHAN-K/awesome-ai-agents-2026&type=Date)](https://star-history.com/#ARUNAGIRINATHAN-K/awesome-ai-agents-2026&Date)
+## ☁️ Cloud Operations & GreenOps
+
+- [GreenOps Agent](https://github.com/raghu-putta/greenops-agent) - 4-agent GCP cost & carbon optimization pipeline. Detects idle VMs, unattached disks, unused reserved IPs, calculates CO₂ footprint, and executes cleanups with human approval. Built on Google ADK + Gemini Flash + Cloud Run.


### PR DESCRIPTION
**Tool Name:** GreenOps-Agent
****Category it belongs in:** Cloud Operations & GreenOps
****GitHub Link:** https://github.com/raghu-putta/greenops-agent
**Site URL (if any): https://github.com/raghu-putta/greenops-agent

Why is this tool on the list?

4-agent GCP cost & carbon optimization pipeline (Google ADK + Gemini Flash + Cloud Run) Identifies idle VMs, unattached disks, unused reserved IPs, calculates CO2 footprint and does cleanups with human approval.

### To do before submission

- [x] repo has a commit in the last **6 months***
- [x] This tool is **nothing like** the existing entries
- [x] Tool has a working README or docs site
- [x] My entry follows the correct format as outlined in the CONTRIBUTING document. md right on!
- [x] The entry is in **alphabetical order** in its section
- [x] All links work and lead to the correct place
- [x] Description is exactly **2 sentences** - no advertising text