### PR TITLE
Add codex-profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ The protocol layer that enables agents to discover tools, communicate with each 
 Sandboxes, web scrapers, browser automation, and networking layers that agents depend on.
 
 - [AgentDock](https://github.com/agentdock/agentdock) - Framework for building and deploying production-ready AI agents with composable node architecture (🏷️ `Python` `Docker` `Platform`).
+- [codex-profiles](https://github.com/Ducksss/codex-profiles) - Bash CLI for switching OpenAI Codex CLI and Desktop profiles with isolated CODEX_HOME directories (🏷️ `Bash` `CLI` `Local`).
 - [Crawl4AI](https://github.com/unclecode/crawl4ai) - Extracts structured data from web pages using LLM-friendly output formats optimized for agent ingestion (🏷️ `Python` `Playwright` `SDK`).
 - [Docling](https://github.com/docling-project/docling) - Parses PDFs, DOCX, and slides into structured text with deep layout understanding for document agents (🏷️ `Python` `PDF` `SDK`).
 - [E2B](https://github.com/e2b-dev/e2b) - Cloud sandboxes for AI agents to run code securely in isolated environments (🏷️ `TypeScript` `Cloud` `Sandbox`).


### PR DESCRIPTION
Adds codex-profiles to Agent Tooling and Infrastructure.

I think it fits this list because the catalogue already includes OpenAI Codex CLI under coding agents, and codex-profiles is local support tooling for that workflow: it switches Codex CLI/Desktop profiles with isolated CODEX_HOME directories so auth, config, sessions, plugins, connector state, caches, and logs do not bleed across work/personal/client contexts.

Install:

```sh
npm install -g codex-profile
# or
brew install Ducksss/tap/codex-profile
```

Repo: https://github.com/Ducksss/codex-profiles

Validation: ran `git diff --check`. I also ran repository-wide `markdownlint-cli README.md`; it reports pre-existing README lint issues unrelated to this one-line addition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added reference to a Bash CLI tool for managing OpenAI Codex profiles within the Agent Tooling and Infrastructure section of the project documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ARUNAGIRINATHAN-K/awesome-ai-agents-2026/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->