### PR TITLE
Add Hyper (AI marketing agent platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ The protocol layer that enables agents to discover tools, communicate with each 
 - [Composio](https://github.com/ComposioHQ/composio) - Integration platform with 250+ pre-built tool connectors for AI agents and LLMs (🏷️ `TypeScript` `Cloud` `API`).
 - [Docker MCP](https://github.com/docker/mcp-gateway) - Docker's MCP gateway CLI plugin for running MCP servers in isolated containers (🏷️ `Go` `Docker` `CLI`).
 - [HCS Agent Protocol](https://github.com/hashgraph/hedera-agent-kit-js) - Hedera open standards for agent identity with trustless P2P communication and 187K+ verified agents (🏷️ `TypeScript` `Hedera` `Protocol`).
+- [Hyper](https://github.com/hyperfx-ai/marketing-skills) - Open-source Agent Skills and a hosted MCP connecting agents to 200+ marketing integrations across paid ads, SEO, analytics, social, and image and video generation, with a human-approval gate on every action (🏷️ `Cloud` `MCP` `Marketing`).
 - [MCP Registry](https://github.com/modelcontextprotocol) - Official Model Context Protocol specification and server implementations for standardized tool access (🏷️ `JSON` `Standard` `Registry`).
 - [mcp-nest](https://github.com/CharanBharathula/mcp-nest) - Unified Model Context Protocol (MCP) server for executing code and managing files (🏷️ `Python` `MCP` `CLI`).
 - [NotFair](https://notfair.co) - Hosted Google Ads MCP server for diagnosing, optimizing, and executing campaign changes via the Google Ads API with a human-approval gate (🏷️ `Cloud` `MCP` `Marketing`).


### PR DESCRIPTION
Adds **Hyper** to the MCP (Model Context Protocol) section, in alphabetical order (between HCS Agent Protocol and MCP Registry), alongside NotFair and other hosted marketing MCP servers.

Hyper is a marketing agent platform: open-source, MIT-licensed Agent Skills plus a hosted MCP connect AI agents to 200+ marketing integrations (paid ads, SEO, analytics, social, image/video generation), with every action gated behind human-in-the-loop approval. Install: `npx skills add hyperfx-ai/marketing-skills`. Source (MIT): https://github.com/hyperfx-ai/marketing-skills. Featured by Supabase: https://supabase.com/customers/hyper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation with an additional agent communication protocol tool entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->