### PR TITLE
Add AgentLine to Voice Agent Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,7 @@ Platforms for building, deploying, and scaling voice-based AI agents across call
 | Bland AI   | Medium  | Yes   | Outbound call automation |
 | PolyAI     | Low     | Yes   | Enterprise scale         |
 
+- [AgentLine](https://agentline.cloud/) - Telephony infrastructure for AI agents — provision phone numbers, make/receive calls, and manage voice pipelines via API (🏷️ `Cloud` `Telephony` `API`).
 - [AssemblyAI](https://www.assemblyai.com) - Speech-to-text API with speaker diarization, sentiment analysis, and summarization for voice agent pipelines (🏷️ `Cloud` `STT` `API`).
 - [Bland AI](https://bland.ai/) - Automates outbound phone calls at scale with SOC2 and HIPAA compliance and CRM integration (🏷️ `Cloud` `Telephony` `API`).
 - [Deepgram](https://deepgram.com) - Sub-300ms speech-to-text and text-to-speech APIs purpose-built for real-time voice agent pipelines (🏷️ `Cloud` `STT/TTS` `API`).


### PR DESCRIPTION
## Summary

Adds [AgentLine](https://agentline.cloud/) to the Voice Agent Platforms section.

AgentLine provides telephony infrastructure for AI agents — provision phone numbers, make/receive calls, and manage voice pipelines via API. 30+ paid users.

## Checklist

- [x] Directly related to AI agents (telephony/voice infrastructure)
- [x] Actively maintained (live SaaS)
- [x] Publicly available
- [x] Not a duplicate
- [x] Functional
- [x] Alphabetically sorted (before AssemblyAI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AgentLine to the Voice Agent Platforms section with documentation covering its telephony infrastructure capabilities, including phone number provisioning, call management, and voice pipeline configuration via API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->