### PR TITLE
Add Agents Launchpad to Newsletters and Communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,6 +768,7 @@ Curated newsletters, podcasts, and communities for staying current with AI agent
 - [r/LocalLLaMA](https://www.reddit.com/r/LocalLLaMA/) - Reddit community for self-hosted LLM users sharing local deployment and agent setup guides (🏷️ `Community` `Reddit` `Forum`).
 - [The Rundown AI](https://www.therundown.ai) - Daily AI digest reaching 600K+ subscribers with concise coverage of agent news and launches (🏷️ `Newsletter` `Daily` `Web`).
 
+- [Agents Launchpad](https://launchpad.smartbizcalc.com) - Community-curated directory of indie AI agents and tools. Browse by category, upvote your favorites, and submit your own agent for free.
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md) for the full update history.


### PR DESCRIPTION
Adds [Agents Launchpad](https://launchpad.smartbizcalc.com) — a community-curated directory of indie AI agents and tools — to the Newsletters and Communities section.

Visitors can browse by project type (MCP servers, CLI tools, hosted agents, etc.), upvote their favorites, and submit their own agents for free. Currently 88+ listings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Agents Launchpad" to the Newsletters and Communities resources, a community-curated directory of indie AI agents and tools enabling users to browse, upvote, and submit entries for free.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->