### PR TITLE
Add Agent Starter and HIG Doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ The protocol layer that enables agents to discover tools, communicate with each 
 - [Composio](https://github.com/ComposioHQ/composio) - Integration platform with 250+ pre-built tool connectors for AI agents and LLMs (🏷️ `TypeScript` `Cloud` `API`).
 - [Docker MCP](https://github.com/docker/mcp-gateway) - Docker's MCP gateway CLI plugin for running MCP servers in isolated containers (🏷️ `Go` `Docker` `CLI`).
 - [HCS Agent Protocol](https://github.com/hashgraph/hedera-agent-kit-js) - Hedera open standards for agent identity with trustless P2P communication and 187K+ verified agents (🏷️ `TypeScript` `Hedera` `Protocol`).
+- [HIG Doctor](https://github.com/raintree-technology/hig-doctor) - Apple HIG audit CLI and MCP server exposing design-guideline lookup and project audits for coding agents across SwiftUI, UIKit, React, Next.js, Flutter, Compose, HTML, and CSS (🏷️ `TypeScript` `MCP` `CLI` `Design`).
 - [Hyper](https://github.com/hyperfx-ai/marketing-skills) - Open-source Agent Skills and a hosted MCP connecting agents to 200+ marketing integrations across paid ads, SEO, analytics, social, and image and video generation, with a human-approval gate on every action (🏷️ `Cloud` `MCP` `Marketing`).
 - [MCP Registry](https://github.com/modelcontextprotocol) - Official Model Context Protocol specification and server implementations for standardized tool access (🏷️ `JSON` `Standard` `Registry`).
 - [mcp-nest](https://github.com/CharanBharathula/mcp-nest) - Unified Model Context Protocol (MCP) server for executing code and managing files (🏷️ `Python` `MCP` `CLI`).
@@ -208,6 +209,7 @@ The protocol layer that enables agents to discover tools, communicate with each 
 Sandboxes, web scrapers, browser automation, and networking layers that agents depend on.
 
 - [AgentDock](https://github.com/agentdock/agentdock) - Framework for building and deploying production-ready AI agents with composable node architecture (🏷️ `Python` `Docker` `Platform`).
+- [Agent Starter](https://github.com/raintree-technology/agent-starter) - Project-local config manager that syncs one `agent.json` manifest into Claude Code, Codex, Cursor, and MCP setup while preserving manual edits and detecting drift (🏷️ `JavaScript` `CLI` `MCP` `Config`).
 - [codex-profiles](https://github.com/Ducksss/codex-profiles) - Bash CLI for switching OpenAI Codex CLI and Desktop profiles with isolated CODEX_HOME directories (🏷️ `Bash` `CLI` `Local`).
 - [Crawl4AI](https://github.com/unclecode/crawl4ai) - Extracts structured data from web pages using LLM-friendly output formats optimized for agent ingestion (🏷️ `Python` `Playwright` `SDK`).
 - [Docling](https://github.com/docling-project/docling) - Parses PDFs, DOCX, and slides into structured text with deep layout understanding for document agents (🏷️ `Python` `PDF` `SDK`).


### PR DESCRIPTION
Adds two open-source Raintree developer tools to the matching categories:\n\n- Agent Starter under Agent Tooling and Infrastructure: one agent.json manifest synced into Claude Code, Codex, Cursor, and MCP setup.\n- HIG Doctor under MCP: Apple HIG lookup and audit tooling exposed through MCP and CLI workflows.\n\nLinks:\n- https://github.com/raintree-technology/agent-starter\n- https://github.com/raintree-technology/hig-doctor\n- https://agent-starter-jade.vercel.app/launch\n- https://apple.raintree.technology/mcp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about HIG Doctor, an Apple HIG audit CLI and MCP server
  * Added information about Agent Starter, a configuration manager for syncing agent setup across tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->