### PR TITLE
Add Kage to Memory and Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@
 - [cognee](https://github.com/topoteretes/cognee) - Knowledge engine for AI agent memory, set up in 6 lines of code with graph-based knowledge extraction (🏷️ `Python` `Neo4j` `SDK`).
 - [Cortex Memory](https://github.com/prem-research/cortex) - Full-stack solution for agent memory covering extraction, vector search, and optimization (🏷️ `Python` `Vector DB` `SDK`).
 - [graphiti](https://github.com/getzep/graphiti) - Build real-time knowledge graphs for AI agents with automatic entity extraction and linking (🏷️ `Python` `Knowledge Graph` `SDK`).
+- [Kage](https://github.com/kage-core/Kage) - Verified, git-native memory for coding agents: captures decisions, runbooks, and bug fixes as plain JSON files in your repo, checks every memory against the code, and withholds stale or contradicted knowledge so agents never act on it (🏷️ `TypeScript` `MCP` `Git-native` `Verified`).
 - [LanceDB](https://github.com/lancedb/lancedb) - Serverless vector search database embedded directly in the agent process with no infrastructure needed (🏷️ `Rust` `Python` `SDK`).
 - [Langmem](https://github.com/langchain-ai/langmem) - Helps agents learn and adapt from their interactions over time with persistent memory (🏷️ `Python` `LangChain` `SDK`).
 - [Mem0](https://github.com/mem0ai/mem0) - Memory layer for AI applications with long-term, short-term, and semantic memory extraction (🏷️ `Python` `Vector` `Cloud`).

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@
 - [cognee](https://github.com/topoteretes/cognee) - Knowledge engine for AI agent memory, set up in 6 lines of code with graph-based knowledge extraction (🏷️ `Python` `Neo4j` `SDK`).
 - [Cortex Memory](https://github.com/prem-research/cortex) - Full-stack solution for agent memory covering extraction, vector search, and optimization (🏷️ `Python` `Vector DB` `SDK`).
 - [graphiti](https://github.com/getzep/graphiti) - Build real-time knowledge graphs for AI agents with automatic entity extraction and linking (🏷️ `Python` `Knowledge Graph` `SDK`).
-- [Kage](https://github.com/kage-core/Kage) - Verified, git-native memory for coding agents: captures decisions, runbooks, and bug fixes as plain JSON files in your repo, checks every memory against the code, and withholds stale or contradicted knowledge so agents never act on it (🏷️ `TypeScript` `MCP` `Git-native` `Verified`).
+- [Kage](https://github.com/kage-core/Kage) - Git-native memory for coding agents that stores decisions and fixes as repo files and verifies them against the codebase, withholding stale knowledge (🏷️ `TypeScript` `MCP` `Git-native`).
 - [LanceDB](https://github.com/lancedb/lancedb) - Serverless vector search database embedded directly in the agent process with no infrastructure needed (🏷️ `Rust` `Python` `SDK`).
 - [Langmem](https://github.com/langchain-ai/langmem) - Helps agents learn and adapt from their interactions over time with persistent memory (🏷️ `Python` `LangChain` `SDK`).
 - [Mem0](https://github.com/mem0ai/mem0) - Memory layer for AI applications with long-term, short-term, and semantic memory extraction (🏷️ `Python` `Vector` `Cloud`).


### PR DESCRIPTION
Adds **Kage** to the Memory and Context section (alphabetical, between graphiti and LanceDB).

[Kage](https://github.com/kage-core/Kage) is verified, git-native memory for coding agents: it captures decisions, runbooks, and bug fixes as plain JSON files committed in your repo, checks every memory against the actual code (at write, recall, and diff time), and withholds stale or contradicted knowledge so agents never act on it. MCP server, zero dependencies, no account.

Entry follows the existing format with tags. Thanks for maintaining the list!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Kage to the Memory and Context section, a Git-native memory tool designed for coding agents supporting TypeScript and MCP protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->