### PR TITLE
Add NotFair Skills (open-source Claude Code SEO & paid-ads agent skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ The protocol layer that enables agents to discover tools, communicate with each 
 - [MCP Registry](https://github.com/modelcontextprotocol) - Official Model Context Protocol specification and server implementations for standardized tool access (🏷️ `JSON` `Standard` `Registry`).
 - [mcp-nest](https://github.com/CharanBharathula/mcp-nest) - Unified Model Context Protocol (MCP) server for executing code and managing files (🏷️ `Python` `MCP` `CLI`).
 - [NotFair](https://notfair.co) - Hosted Google Ads MCP server for diagnosing, optimizing, and executing campaign changes via the Google Ads API with a human-approval gate (🏷️ `Cloud` `MCP` `Marketing`).
+- [NotFair Skills](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads, connecting to live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP (🏷️ `TypeScript` `MCP` `Claude Code`).
 - [Toolhouse](https://toolhouse.ai) - Cloud-hosted tool infrastructure for agents with optimized execution and low-latency access (🏷️ `Python` `Cloud` `API`).
 - [Zapier MCP Server](https://zapier.com/mcp) - Connect agents to 7,000+ app integrations via MCP, powered by Zapier's automation platform (🏷️ `Cloud` `Zapier` `API`).
 - [zero-api-key-web-search](https://github.com/wd041216-bit/zero-api-key-web-search) - Free web search toolkit for AI agents with no API keys, MCP server support (🏷️ `Python` `MCP` `Search`).


### PR DESCRIPTION
Hi, thanks for maintaining this list — it's a genuinely useful resource.

I'd like to add **NotFair Skills** ([github.com/nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)), an open-source set of Claude Code agent skills for SEO, GEO, Google Ads, and Meta Ads. The project has ~2.9k stars and is MIT-licensed.

It fits the MCP section because it works entirely through live data connections: Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. The skills cover things like site audits, keyword research, schema markup, wasted-spend detection, and Meta ROAS analysis — all runnable directly from Claude Code.

I placed it alphabetically next to the existing `[NotFair](https://notfair.co)` entry (the hosted product), since this is the open-source counterpart. Happy to rename the entry, move it to a different section, or trim the description if you'd prefer.

Thanks again for your time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to include NotFair Skills as an available MCP integration, featuring open-source Claude Code skills and connections to Google Ads, Meta Ads, Google Search Console, and Google Analytics MCPs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->