### PR TITLE
Add AiToolsObserver to Newsletters and Communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -772,6 +772,7 @@ AI agents for mental health support, cognitive training, and therapy-adjacent ap
 Curated newsletters, podcasts, and communities for staying current with AI agent development.
 
 - [AI Engineering Newsletter](https://www.latent.space) - AI engineering podcast and newsletter by Swyx and Alessio covering agent architectures and tooling (🏷️ `Newsletter` `Podcast` `Web`).
+- [AiToolsObserver](https://aitoolsobserver.com) - AI discovery and intelligence platform covering AI agents, ecosystem trends, comparisons, and practical use cases (🏷️ `Directory` `News` `Web`).
 - [aibtc.news](https://aibtc.news) - Bitcoin-focused agent news platform with bounties and classifieds for the agent economy (🏷️ `Newsletter` `Bitcoin` `Web`).
 - [Awesome Agents Newsletter](https://awesomeagents.substack.com) - Weekly curated tools and reviews covering the latest in AI agent development (🏷️ `Newsletter` `Weekly` `Web`).
 - [r/ClaudeAI](https://www.reddit.com/r/ClaudeAI/) - Reddit community for Claude users sharing agent workflows, prompts, and integration patterns (🏷️ `Community` `Reddit` `Forum`).


### PR DESCRIPTION
## What changed

Adds AiToolsObserver to **Newsletters and Communities**.

AiToolsObserver publishes AI ecosystem news and trend coverage alongside curated discovery, comparisons, and practical use cases for AI agents and tools.

## Fit and disclosure

The entry is positioned as an agent ecosystem discovery and news resource, not as an agent framework. I am affiliated with AiToolsObserver.

## Validation

- One-sentence factual description
- Alphabetical placement
- Official working URL
- No duplicate URL in the README
- `git diff --check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AiToolsObserver to the Newsletters and Communities section as a new Directory/News/Web resource, providing users with an additional source for AI tool updates and industry insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->