### PR TITLE
Add LoopTroop to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@
 - [Goose](https://github.com/aaif-goose/goose) - Open-source extensible AI agent that goes beyond code suggestions, installs, executes, edits, and tests with any LLM (🏷️ `Rust` `CLI` `Local`).
 - [JetBrains AI](https://www.jetbrains.com/ai/) - Deep AI integration across all JetBrains IDEs with context-aware completions and refactoring (🏷️ `Kotlin` `JetBrains` `IDE`).
 - [Kiro](https://kiro.dev) - Spec-driven development agent that writes specs, auto-generates tasks, implements code, and automates DevOps workflows (🏷️ `Cloud` `AWS` `IDE`).
-- [LoopTroop](https://github.com/looptroop-ai/LoopTroop) - Local GUI orchestrator for AI coding agents where an LLM Council plans, atomic beads execute in isolated git worktrees, and a Ralph Loop retries failures with fresh context to fight context rot (🏷️ `TypeScript` `Local` `OpenCode`).
+- [LoopTroop](https://github.com/looptroop-ai/LoopTroop) - Local GUI orchestrator for AI coding agents where an LLM Council plans, atomic beads execute in isolated Git worktrees, and a Ralph Loop retries failures with fresh context to fight context rot (🏷️ `TypeScript` `Local` `OpenCode`).
 - [Open Interpreter](https://github.com/openinterpreter/open-interpreter) - Execute code locally via natural-language model instructions with a ChatGPT-like interface (🏷️ `Python` `CLI` `Local`).
 - [opencode](https://github.com/anomalyco/opencode) - Open-source coding agent available as a desktop application with a visual interface (🏷️ `TypeScript` `Electron` `Desktop`).
 - [OpenHands](https://github.com/OpenHands/OpenHands) - AI-driven development platform that writes, tests, and deploys code autonomously (🏷️ `Python` `Docker` `Web`).

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@
 - [Goose](https://github.com/aaif-goose/goose) - Open-source extensible AI agent that goes beyond code suggestions, installs, executes, edits, and tests with any LLM (🏷️ `Rust` `CLI` `Local`).
 - [JetBrains AI](https://www.jetbrains.com/ai/) - Deep AI integration across all JetBrains IDEs with context-aware completions and refactoring (🏷️ `Kotlin` `JetBrains` `IDE`).
 - [Kiro](https://kiro.dev) - Spec-driven development agent that writes specs, auto-generates tasks, implements code, and automates DevOps workflows (🏷️ `Cloud` `AWS` `IDE`).
+- [LoopTroop](https://github.com/looptroop-ai/LoopTroop) - Local GUI orchestrator for AI coding agents where an LLM Council plans, atomic beads execute in isolated git worktrees, and a Ralph Loop retries failures with fresh context to fight context rot (🏷️ `TypeScript` `Local` `OpenCode`).
 - [Open Interpreter](https://github.com/openinterpreter/open-interpreter) - Execute code locally via natural-language model instructions with a ChatGPT-like interface (🏷️ `Python` `CLI` `Local`).
 - [opencode](https://github.com/anomalyco/opencode) - Open-source coding agent available as a desktop application with a visual interface (🏷️ `TypeScript` `Electron` `Desktop`).
 - [OpenHands](https://github.com/OpenHands/OpenHands) - AI-driven development platform that writes, tests, and deploys code autonomously (🏷️ `Python` `Docker` `Web`).


### PR DESCRIPTION
## What does this PR do?

- [x] Adds a new tool

---

## For new tool additions

**Tool name:** LoopTroop
**Category it belongs in:** Coding Agents
**GitHub URL:** https://github.com/looptroop-ai/LoopTroop
**Site URL (if any):** https://www.looptroop.ovh

### Why does this tool belong on the list?

LoopTroop is a local GUI orchestrator that turns a coding ticket into a merged PR, the same job Devin, OpenHands, and SWE-agent do. The distinct part is how it fights context rot: an LLM Council drafts and votes on the plan, work is split into atomic "beads" that run in isolated git worktrees, and a "Ralph Loop" retries failed beads with a fresh context window instead of continuing a polluted chat. It's built on OpenCode, MIT licensed, and actively maintained.

### Pre-submission checklist

- [x] The repo has had a commit in the last **6 months**
- [x] This tool is **meaningfully different** from existing entries
- [x] The tool has a working README or docs site
- [x] My entry follows the [format in CONTRIBUTING.md](https://github.com/ARUNAGIRINATHAN-K/awesome-ai-agents-2026/blob/main/CONTRIBUTING.md) exactly
- [x] The entry is placed in **alphabetical order** within its section
- [x] All links open correctly and go to the right place
- [x] Description is exactly **one sentence** — no promotional language


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new LoopTroop entry to the Coding Agents section, including its GitHub link and platform/language tag metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->